### PR TITLE
Update to ingenerator/kohana-dependencies in place of Zeelot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### Unreleased
 
+## v0.2.0 (2018-02-20)
+
+* Update to use ingenerator/kohana-dependencies at 0.9 version
+
 ## v0.1.1 (2018-02-15)
 
 * Added customised DependencyContainer with explicit definition of included module configs.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 A set of useful extra classes for Kohana - including wrappers that make it easier to inject
 or fake parts of the core Kohana underlying behaviour.
 
-[![Build Status](https://travis-ci.org/ingenerator/kohana-extras.svg?branch=0.1.x)](https://travis-ci.org/ingenerator/kohana-extras)
+[![Build Status](https://travis-ci.org/ingenerator/kohana-extras.svg?branch=0.2.x)](https://travis-ci.org/ingenerator/kohana-extras)
 
 
 # Installing kohana-extras

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^5.5",
     "kohana/core": "3.3.*",
-    "zeelot/kohana-dependencies": "^0.7.0"
+    "ingenerator/kohana-dependencies": "^0.9.0"
   },
   "require-dev": {
     "kohana/koharness": "*@dev",
@@ -29,12 +29,6 @@
   "autoload": {
     "psr-4": {
       "Ingenerator\\KohanaExtras\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-0": {
-      "Dependency_": "vendor/zeelot/kohana-dependencies/classes",
-      "Kohana_Dependency_": "vendor/zeelot/kohana-dependencies/classes"
     }
   },
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^5.5",
     "kohana/core": "3.3.*",
-    "ingenerator/kohana-dependencies": "^0.9.0"
+    "ingenerator/kohana-dependencies": "^0.9.1"
   },
   "require-dev": {
     "kohana/koharness": "*@dev",


### PR DESCRIPTION
No longer needs to be registered as a module or have custom auto
loader as it is now defined to autoload it's own classes.