### PR TITLE
Define SMTP as default Swiftmailer transport

### DIFF
--- a/src/DependencyFactory/SwiftMailerFactory.php
+++ b/src/DependencyFactory/SwiftMailerFactory.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @author    Andrew Coulton <andrew@ingenerator.com>
+ * @author    Craig Gosman <craig@ingenerator.com>
  * @licence   proprietary
  */
 
@@ -17,6 +18,9 @@ use Symfony\Component\Validator\Validation;
 class SwiftMailerFactory extends OptionalDependencyFactory
 {
 
+    /**
+     * @return array
+     */
     public static function definitions()
     {
         static::requireClass(\Swift_Mailer::class, 'swiftmailer/swiftmailer');
@@ -33,13 +37,33 @@ class SwiftMailerFactory extends OptionalDependencyFactory
                 ],
                 'transport' => [
                     '_settings' => [
-                        'class'       => \Swift_SendmailTransport::class,
-                        'constructor' => 'newInstance',
-                        'arguments'   => [],
+                        'class'       => static::class,
+                        'constructor' => 'buildSmtpTransport',
+                        'arguments'   => ['@email.relay@'],
                         'shared'      => TRUE,
                     ],
                 ],
             ],
         ];
+    }
+
+    public static function buildSmtpTransport(array $relay)
+    {
+        $config = array_merge(
+            [
+                'host'     => 'localhost',
+                'port'     => 25,
+                'security' => NULL,
+                'username' => NULL,
+                'password' => NULL,
+            ],
+            $relay
+        );
+
+        $transport = new \Swift_SmtpTransport($config['host'], $config['port'], $config['security']);
+        $transport->setUsername($config['username']);
+        $transport->setPassword($config['password']);
+
+        return $transport;
     }
 }

--- a/test/unit/DependencyFactory/SwiftMailerFactoryTest.php
+++ b/test/unit/DependencyFactory/SwiftMailerFactoryTest.php
@@ -14,7 +14,7 @@ use Ingenerator\KohanaExtras\DependencyFactory\SwiftMailerFactory;
 class SwiftMailerFactoryTest extends AbstractDependencyFactoryTest
 {
 
-    public function test_it_defines_entity_manager()
+    public function test_it_defines_swiftmailer_mailer()
     {
         $this->assertOptionalService(
             function () {
@@ -26,12 +26,12 @@ class SwiftMailerFactoryTest extends AbstractDependencyFactoryTest
         );
     }
 
-    public function test_it_defines_raw_pdo_connection()
+    public function test_it_defines_swiftmailer_transport()
     {
         $this->assertOptionalService(
             function () {
                 $this->assertInstanceOf(
-                    \Swift_SendmailTransport::class,
+                    \Swift_SmtpTransport::class,
                     $this->assertDefinesService('swiftmailer.transport', SwiftMailerFactory::definitions())
                 );
             }


### PR DESCRIPTION
No requirement to attach config, defaults of localhost:25 with no security, username or password will be used. (which are Swiftmailer defaults already)

For dev boxes a simple `['host'=>'localhost', 'port'=>1025]` to use mailcatcher if you have it

If down the line we stop going via a local postfix relay then swift can send anywhere directly.

For SSL or TLS encryption to work your PHP installation must have appropriate OpenSSL transports wrappers. You can check if "tls" and/or "ssl" are present in your PHP installation by using the PHP function `stream_get_transports()`.

See https://swiftmailer.symfony.com/docs/sending.html for more

