### PR TITLE
Add UrlReverseRouter with implementations to get URLs for controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+## v1.1.0 (2020-02-12)
+
 * Add UrlReverseRouter with implementation to get URLs from defined HttpMethodRoutes, and mock
   to generate them predictably from the parameters independent of any application routing rules.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Unreleased
 
+* Add UrlReverseRouter with implementation to get URLs from defined HttpMethodRoutes, and mock
+  to generate them predictably from the parameters independent of any application routing rules.
+
 ## v1.0.1 (2019-04-03)
 
 * Bump missed dependencies

--- a/src/DependencyFactory/UrlReverseRouterFactory.php
+++ b/src/DependencyFactory/UrlReverseRouterFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Ingenerator\KohanaExtras\DependencyFactory;
+
+use Ingenerator\KohanaExtras\Routing\HttpMethodRouteReverseRouter;
+
+class UrlReverseRouterFactory
+{
+    /**
+     * @return array
+     */
+    public static function definitions()
+    {
+        return [
+            'util' => [
+                'url_reverse_router' => [
+                    '_settings' => [
+                        'class'     => HttpMethodRouteReverseRouter::class,
+                        'arguments' => [
+                            '%kohana.routes%',
+                        ],
+                        'shared'    => TRUE,
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Routing/AbstractReverseRouter.php
+++ b/src/Routing/AbstractReverseRouter.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace Ingenerator\KohanaExtras\Routing;
+
+
+abstract class AbstractReverseRouter
+{
+
+    /**
+     * @param array $params
+     *
+     * @return array
+     */
+    protected function stringifyAndValidateParams(array $params): array
+    {
+        foreach ($params as $param => $param_value) {
+            if ($param_value instanceof URLIdentifiableEntity) {
+                $params[$param] = $param_value->getURLId();
+            } else {
+                if (\is_string($param_value) OR \is_int($param_value)) {
+                    $params[$param] = $param_value;
+                } else {
+                    throw ReverseRoutingException::invalidParameterType($param, $param_value);
+                }
+            }
+        }
+
+        return $params;
+    }
+
+}

--- a/src/Routing/HttpMethodRoute.php
+++ b/src/Routing/HttpMethodRoute.php
@@ -172,5 +172,14 @@ class HttpMethodRoute extends \Route
         return parent::uri($params);
     }
 
+    /**
+     * List the defined action classes, as a hash of {controller-name-in-url} => {FQ class name}
+     *
+     * @return string[]
+     */
+    public function listActionClasses():array
+    {
+        return $this->action_classes;
+    }
 
 }

--- a/src/Routing/HttpMethodRouteReverseRouter.php
+++ b/src/Routing/HttpMethodRouteReverseRouter.php
@@ -1,0 +1,90 @@
+<?php
+
+
+namespace Ingenerator\KohanaExtras\Routing;
+
+/**
+ * Maps controllers and parameters back to URLs using HttpMethodRoutes defined in the app
+ *
+ */
+class HttpMethodRouteReverseRouter extends AbstractReverseRouter implements UrlReverseRouter
+{
+
+    /**
+     * @var string[]
+     */
+    protected $controller_name_map;
+
+    /**
+     * @var \Route[]
+     */
+    protected $controller_route_map;
+
+    /**
+     * @var \Ingenerator\KohanaExtras\Routing\HttpMethodRoute[]
+     */
+    protected $http_method_routes = [];
+
+    /**
+     *
+     * @param \Route[] $routes Note: Only HttpMethodRoute instances will actually be considered
+     */
+    public function __construct(array $routes)
+    {
+        foreach ($routes as $route) {
+            if ($route instanceof HttpMethodRoute) {
+                $this->http_method_routes[] = $route;
+            } elseif ( ! $route instanceof \Route) {
+                throw new \InvalidArgumentException(
+                    __CLASS__.' expected array of routes, got '.\gettype($route)
+                );
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getUrl(string $controller_class, array $params = [], array $query = []): string
+    {
+        if ( ! $this->controller_route_map) {
+            $this->compileControllerRouteMap();
+        }
+
+        // Routes are defined with a leading \ on the controller class in HttpMethodRoute
+        $controller_class = '\\'.ltrim($controller_class, '\\');
+
+        if ( ! isset($this->controller_route_map[$controller_class])) {
+            throw ReverseRoutingException::noRouteToController($controller_class);
+        }
+
+        $params = $this->stringifyAndValidateParams($params);
+        $params['controller'] = $this->controller_name_map[$controller_class];
+        $url = \URL::site(
+            $this->controller_route_map[$controller_class]->uri($params)
+        );
+
+        if ( ! empty($query)) {
+            $url .= '?'.\http_build_query($query);
+        }
+
+        return $url;
+    }
+
+    protected function compileControllerRouteMap()
+    {
+        $this->controller_route_map = [];
+        $this->controller_name_map  = [];
+
+        foreach ($this->http_method_routes as $route) {
+            foreach ($route->listActionClasses() as $url_name => $class) {
+                if (isset($this->controller_route_map[$class])) {
+                    throw ReverseRoutingException::multipleRoutesToController($class);
+                }
+                $this->controller_route_map[$class] = $route;
+                $this->controller_name_map[$class]  = $url_name;
+            }
+        }
+    }
+
+}

--- a/src/Routing/MockReverseRouter.php
+++ b/src/Routing/MockReverseRouter.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace Ingenerator\KohanaExtras\Routing;
+
+
+/**
+ * Use in unit tests etc to generate predictable URLs for assertions independent of actual route definitions
+ */
+class MockReverseRouter extends AbstractReverseRouter implements UrlReverseRouter
+{
+
+    public function getUrl(string $controller_class, array $params = [], array $query = []): string
+    {
+        ksort($params);
+        $parts = [$controller_class];
+        foreach ($this->stringifyAndValidateParams($params) as $k => $v) {
+            $parts[] = $k.'='.$v;
+        }
+
+        if ($query) {
+            ksort($query);
+            $querystring = '?'.\http_build_query($query);
+        } else {
+            $querystring = '';
+        }
+
+        return '{routed:'.implode('/', $parts).$querystring.'}';
+    }
+
+}

--- a/src/Routing/ReverseRoutingException.php
+++ b/src/Routing/ReverseRoutingException.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace Ingenerator\KohanaExtras\Routing;
+
+
+class ReverseRoutingException extends \InvalidArgumentException
+{
+
+    public static function noRouteToController(string $controller_class)
+    {
+        return new static('No route defined to controller `'.$controller_class.'`');
+    }
+
+    public static function multipleRoutesToController(string $controller_class)
+    {
+        return new static('Multiple routes defined to controller `'.$controller_class.'`');
+    }
+
+    public static function invalidParameterType($param, $param_value)
+    {
+        if (is_object($param_value)) {
+            $type = \get_class($param_value);
+        } else {
+            $type = \gettype($param_value);
+        }
+
+        return new static (
+            sprintf(
+                'Invalid parameter type for `%s` (%s) - expected string, int or URLIdentifiableEntity',
+                $param,
+                $type
+            )
+        );
+    }
+}

--- a/src/Routing/URLIdentifiableEntity.php
+++ b/src/Routing/URLIdentifiableEntity.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Ingenerator\KohanaExtras\Routing;
+
+
+interface URLIdentifiableEntity
+{
+
+    public function getURLId(): string;
+}

--- a/src/Routing/UrlReverseRouter.php
+++ b/src/Routing/UrlReverseRouter.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace Ingenerator\KohanaExtras\Routing;
+
+
+/**
+ * Provides a mechanism to reverse route controllers and params back to URLs
+ *
+ * @package Ingenerator\KohanaExtras\Routing
+ */
+interface UrlReverseRouter
+{
+
+    /**
+     * Generate a URL to a controller/parameters set
+     *
+     * Parameters may include URLIdentifiableEntity classes, which will be dynamically converted
+     * back to the related url string. For example:
+     *
+     *   // $booking->getUrlId() returns a string id for the content
+     *   ->getUrl(ViewBookingController::class, ['id' => $booking]);
+     *
+     *   // $article->getUrlId() returns a string unique slug for the content
+     *   ->getUrl(ViewArticleController::class, ['slug' => $article]);
+     *
+     * @param string $controller_class The FQCN of the controller to route back to
+     * @param array  $params           Parameters to include in the route
+     * @param array  $query            Any optional querystring args to encode and append
+     *
+     * @return string the URL
+     */
+    public function getUrl(string $controller_class, array $params = [], array $query = []): string;
+
+}

--- a/test/mock/Routing/UrlIdentifiableStringStub.php
+++ b/test/mock/Routing/UrlIdentifiableStringStub.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace test\mock\Ingenerator\KohanaExtras\Routing;
+
+use Ingenerator\KohanaExtras\Routing\URLIdentifiableEntity;
+
+class UrlIdentifiableStringStub implements URLIdentifiableEntity
+{
+    private $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getURLId(): string
+    {
+        return $this->id;
+    }
+
+}

--- a/test/unit/DependencyFactory/UrlReverseRouterFactoryTest.php
+++ b/test/unit/DependencyFactory/UrlReverseRouterFactoryTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace test\unit\Ingenerator\KohanaExtras\DependencyFactory;
+
+
+use Ingenerator\KohanaExtras\DependencyFactory\KohanaCoreFactory;
+use Ingenerator\KohanaExtras\DependencyFactory\UrlReverseRouterFactory;
+use Ingenerator\KohanaExtras\Routing\HttpMethodRouteReverseRouter;
+
+class UrlReverseRouterFactoryTest extends AbstractDependencyFactoryTest
+{
+    public function test_it_provides_http_method_route_reverse_router()
+    {
+
+        $service = $this->assertDefinesService(
+            'util.url_reverse_router',
+            \Arr::merge(
+                KohanaCoreFactory::definitions(),
+                UrlReverseRouterFactory::definitions()
+            )
+        );
+        $this->assertInstanceOf(HttpMethodRouteReverseRouter::class, $service);
+    }
+}

--- a/test/unit/Routing/HttpMethodRouteReverseRouterTest.php
+++ b/test/unit/Routing/HttpMethodRouteReverseRouterTest.php
@@ -1,0 +1,277 @@
+<?php
+
+
+namespace test\unit\Ingenerator\KohanaExtras\Routing;
+
+use Ingenerator\KohanaExtras\Routing\HttpMethodRoute;
+use Ingenerator\KohanaExtras\Routing\HttpMethodRouteReverseRouter;
+use Ingenerator\KohanaExtras\Routing\ReverseRoutingException;
+use Ingenerator\KohanaExtras\Routing\UrlReverseRouter;
+use PHPUnit\Framework\TestCase;
+use test\mock\Ingenerator\KohanaExtras\Routing\UrlIdentifiableStringStub;
+
+
+class HttpMethodRouteReverseRouterTest extends TestCase
+{
+    protected $routes = [];
+
+    public function test_it_is_initialisable()
+    {
+        $subject = $this->newSubject();
+        $this->assertInstanceOf(HttpMethodRouteReverseRouter::class, $subject);
+        $this->assertInstanceOf(UrlReverseRouter::class, $subject);
+    }
+
+    public function test_it_throws_if_any_routes_provided_are_not_routes()
+    {
+        $this->routes = ['junk'];
+        $this->expectException(\InvalidArgumentException::class);
+        $this->newSubject();
+    }
+
+    public function test_its_get_url_method_throws_if_no_route_to_controller()
+    {
+        $this->routes = [
+            new HttpMethodRoute(
+                'home/my-controller',
+                ['Controller\Anything\SomeController']
+            ),
+        ];
+        $subject      = $this->newSubject();
+        $this->expectException(ReverseRoutingException::class);
+        $this->expectExceptionMessage('No route defined to controller');
+        $subject->getURL('Controller\Anything');
+    }
+
+    public function test_it_ignores_legacy_kohana_routes()
+    {
+        // In theory this route matches the requested controller, but it is very challenging
+        // to do the runtime parsing to work out which route would actually match due to wildcard
+        // and order-of-definition matching. You want the new behaviour, define new HTTPMethodRoutes
+        $this->routes = [
+            (new \Route('home/<controller>'))->defaults(['controller' => 'Controller\DoStuff']),
+        ];
+        $subject      = $this->newSubject();
+        $this->expectException(ReverseRoutingException::class);
+        $this->expectExceptionMessage('No route defined to controller');
+        $subject->getURL('Controller\DoStuff');
+    }
+
+
+    public function test_its_get_url_method_throws_if_multiple_routes_to_controller()
+    {
+        $this->routes = [
+            new HttpMethodRoute(
+                'home/my-controller',
+                ['Controller\MyController']
+            ),
+            new HttpMethodRoute(
+                'home/my-controller-legacy-path',
+                ['Controller\MyController']
+            ),
+        ];
+        $subject      = $this->newSubject();
+        $this->expectException(ReverseRoutingException::class);
+        $this->expectExceptionMessage('Multiple routes defined to controller');
+        $subject->getURL('Controller\MyController');
+    }
+
+    public function provider_controllers_with_no_params()
+    {
+        return [
+            [
+                [
+                    new HttpMethodRoute(
+                        'home/explicit-controller',
+                        ['Controller\ExplicitDoSomething']
+                    ),
+                ],
+                'Controller\ExplicitDoSomething',
+                \URL::site('home/explicit-controller'),
+            ],
+            [
+                [
+                    new HttpMethodRoute(
+                        'anywhere/<controller>',
+                        [
+                            'Controller\ExplicitDoSomethingController',
+                            'Controller\Whatever\WelcomeController',
+                        ]
+                    ),
+                ],
+                'Controller\Whatever\WelcomeController',
+                \URL::site('anywhere/welcome'),
+            ],
+            [
+                [
+                    new HttpMethodRoute(
+                        'anywhere/<controller>',
+                        [
+                            'Controller\ExplicitDoSomethingController',
+                            'Controller\Whatever\WelcomeController',
+                        ]
+                    ),
+                    new HttpMethodRoute(
+                        '<controller>',
+                        [
+                            'Controller\RootControllerOne',
+                            'Controller\Whatever\RootControllerTwo',
+                            'Controller\Whatever\RootControllerThree',
+                        ]
+                    ),
+                ],
+                'Controller\Whatever\RootControllerTwo',
+                \URL::site('root-controller-two'),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provider_controllers_with_no_params
+     */
+    public function test_its_get_url_method_returns_url_for_controller_with_no_params(
+        $routes,
+        $controller,
+        $expect_url
+    ) {
+        $this->routes = $routes;
+        $this->assertSame($expect_url, $this->newSubject()->getUrl($controller));
+    }
+
+    public function test_its_get_url_method_returns_url_for_controller_with_required_params()
+    {
+        $this->routes = [
+            new HttpMethodRoute(
+                'anywhere/<controller>/<id>',
+                [
+                    'Controller\ExplicitDoSomethingController',
+                ]
+            ),
+        ];
+        $this->assertSame(
+            \URL::site('anywhere/explicit-do-something/1939'),
+            $this->newSubject()->getUrl('Controller\ExplicitDoSomethingController', ['id' => 1939])
+        );
+    }
+
+    /**
+     * @testWith [{"slug": "my-file"}, "any/file/my-file-current"]
+     *           [{"slug": "my-file", "format": "png"}, "any/file/my-file-current.png"]
+     *           [{"slug": "my-file", "format": "png", "version": "custom"}, "any/file/my-file-custom.png"]
+     */
+    public function test_its_get_url_method_returns_url_with_or_without_optional_params(
+        $params,
+        $expect
+    ) {
+        $this->routes = [
+            (new HttpMethodRoute(
+                'any/<controller>/<slug>-<version>(.<format>)',
+                [
+                    'Controller\Download\FileController',
+                ]
+            ))->defaults(['version' => 'current']),
+        ];
+
+        $this->assertSame(
+            \URL::site($expect),
+            $this->newSubject()->getUrl('Controller\Download\FileController', $params)
+        );
+    }
+
+    public function provider_url_identifiable_entities()
+    {
+        return [
+            [
+                ['slug' => 'hardcoded', 'id' => new UrlIdentifiableStringStub(19238)],
+                \URL::site('do-thing/19238-hardcoded'),
+            ],
+            [
+                ['slug' => new UrlIdentifiableStringStub('this-is-the-slug'), 'id' => 19482],
+                \URL::site('do-thing/19482-this-is-the-slug'),
+            ],
+            [
+                [
+                    'slug' => new UrlIdentifiableStringStub('this-is-the-slug'),
+                    'id'   => new UrlIdentifiableStringStub('this-is-id'),
+                ],
+                \URL::site('do-thing/this-is-id-this-is-the-slug'),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provider_url_identifiable_entities
+     */
+    public function test_its_get_url_method_can_convert_url_identifiable_identity_param_to_id(
+        array $params,
+        string $expect
+    ) {
+        $this->routes = [
+            new HttpMethodRoute(
+                '<controller>/<id>-<slug>',
+                [
+                    'Controller\DoThingController',
+                ]
+            ),
+        ];
+
+        $this->assertSame(
+            $expect,
+            $this->newSubject()->getUrl('Controller\DoThingController', $params)
+        );
+    }
+
+    public function provider_invalid_params()
+    {
+        return [
+            [new \DateTimeImmutable],
+            [new \stdClass],
+            [TRUE],
+        ];
+    }
+
+    /**
+     * @dataProvider provider_invalid_params
+     */
+    public function test_its_get_url_method_throws_if_any_param_not_scalar_or_url_identifiable(
+        $invalid
+    ) {
+        $this->routes = [
+            new HttpMethodRoute(
+                '<invalid_param>',
+                [
+                    'Controller\DoThingController',
+                ]
+            ),
+        ];
+        $subject      = $this->newSubject();
+        $this->expectException(ReverseRoutingException::class);
+        $this->expectExceptionMessage('Invalid parameter type');
+        $subject->getUrl('Controller\DoThingController', ['invalid_param' => $invalid]);
+    }
+
+    public function test_its_get_url_method_optionally_encodes_querystring()
+    {
+        $this->routes = [
+            new HttpMethodRoute(
+                'anywhere/<controller>/<id>',
+                [
+                    'Controller\ExplicitDoSomethingController',
+                ]
+            ),
+        ];
+        $this->assertSame(
+            \URL::site('anywhere/explicit-do-something/1939?filter_by=date&filter=today'),
+            $this->newSubject()->getUrl(
+                'Controller\ExplicitDoSomethingController',
+                ['id' => 1939],
+                ['filter_by' => 'date', 'filter' => 'today']
+            )
+        );
+    }
+
+    protected function newSubject()
+    {
+        return new HttpMethodRouteReverseRouter($this->routes);
+    }
+}

--- a/test/unit/Routing/HttpMethodRouteTest.php
+++ b/test/unit/Routing/HttpMethodRouteTest.php
@@ -7,9 +7,9 @@
 namespace test\unit\Ingenerator\KohanaExtras\Routing;
 
 
+use Ingenerator\KohanaExtras\Routing\HttpMethodRoute;
 use test\mock\Kohana\Request\HtmlRequestStub;
 use test\unit\BaseTestCase;
-use Ingenerator\KohanaExtras\Routing\HttpMethodRoute;
 
 class HttpMethodRouteTest extends \PHPUnit\Framework\TestCase
 {
@@ -130,6 +130,26 @@ class HttpMethodRouteTest extends \PHPUnit\Framework\TestCase
         $route   = new HttpMethodRoute('<controller>', $actions);
         $matches = $route->matches(\Request::with(['uri' => $url]));
         $this->assertSame($expect, $matches['controller']);
+    }
+
+    public function test_it_lists_defined_action_classes_as_controller_name_and_class()
+    {
+        $route = new HttpMethodRoute(
+            '<controller>',
+            [
+                '\\Controller\\Entity\\DoThings',
+                'Action\\Entity\\OtherThingsController',
+            ]
+        );
+        $this->assertSame(
+            [
+                'do-things'    => '\\Controller\\Entity\\DoThings',
+                // Note the leading \ is prepended in the definition even though it wasn't passed
+                // in the constructor.
+                'other-things' => '\\Action\\Entity\\OtherThingsController',
+            ],
+            $route->listActionClasses()
+        );
     }
 
     /**

--- a/test/unit/Routing/MockReverseRouterTest.php
+++ b/test/unit/Routing/MockReverseRouterTest.php
@@ -1,0 +1,69 @@
+<?php
+
+
+namespace test\unit\Ingenerator\KohanaExtras\Routing;
+
+
+use Ingenerator\KohanaExtras\Routing\MockReverseRouter;
+use Ingenerator\KohanaExtras\Routing\UrlReverseRouter;
+use PHPUnit\Framework\TestCase;
+use test\mock\Ingenerator\KohanaExtras\Routing\UrlIdentifiableStringStub;
+
+class MockReverseRouterTest extends TestCase
+{
+
+    public function it_is_initialisable()
+    {
+        $subject = $this->newSubject();
+        $this->assertInstanceOf(MockReverseRouter::class, $subject);
+        $this->assertInstanceOf(UrlReverseRouter::class, $subject);
+    }
+
+    public function test_its_get_url_returns_controller_class_with_prefix()
+    {
+        $this->assertSame(
+            '{routed:Controller\My\ActionController}',
+            $this->newSubject()->getUrl('Controller\My\ActionController')
+        );
+    }
+
+    public function test_its_get_url_includes_all_provided_params_in_alpha_order()
+    {
+        $this->assertSame(
+            '{routed:Controller\My\ActionController/id=15/slug=some-stuff}',
+            $this->newSubject()->getUrl(
+                'Controller\My\ActionController',
+                ['slug' => 'some-stuff', 'id' => 15]
+            )
+        );
+    }
+
+    public function test_its_get_url_converts_url_identifiable_entities()
+    {
+        $this->assertSame(
+            '{routed:Controller\My\ActionController/slug=entity-slug}',
+            $this->newSubject()->getUrl(
+                'Controller\My\ActionController',
+                ['slug' => new UrlIdentifiableStringStub('entity-slug')]
+            )
+        );
+    }
+
+    public function test_its_get_url_includes_querystring_in_alpha_order()
+    {
+        $this->assertSame(
+            '{routed:Controller_Anything/id=15?date=today&version_from=123}',
+            $this->newSubject()->getUrl(
+                'Controller_Anything',
+                ['id' => 15],
+                ['version_from' => 123, 'date' => 'today']
+            )
+        );
+    }
+
+    protected function newSubject()
+    {
+        return new MockReverseRouter;
+    }
+}
+


### PR DESCRIPTION
The mock implementation provides simple predictable strings based on
provided parameters, so that they can be easily used in unit tests.

The real implementation uses the HttpMethodRoutes defined in the app
to find the canonical url for any given controller, and automatically
populate a url with the appropriate parameters / querystring args.