### PR TITLE
Drop prophecy for unit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
     "kohana/koharness": "*@dev",
     "phpunit/phpunit": "^9.5.5",
     "symfony/process": "^5.4",
-    "mikey179/vfsstream": "^1.6.11",
-    "phpspec/prophecy-phpunit": "^2.0"
+    "mikey179/vfsstream": "^1.6.11"
   },
   "suggest": {
     "maximebf/debugbar": "^1.14 to use the debug bar in development environments",

--- a/test/unit/Logger/KohanaPSRLoggerTest.php
+++ b/test/unit/Logger/KohanaPSRLoggerTest.php
@@ -2,26 +2,32 @@
 
 namespace test\unit\Ingenerator\KohanaExtras;
 
+use Exception;
 use Ingenerator\KohanaExtras\Logger\KohanaPSRLogger;
 use InvalidArgumentException;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
+use Kohana_Exception;
+use Log;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use stdClass;
+use const PHP_EOL;
 
-class KohanaPSRLoggerTest extends \PHPUnit\Framework\TestCase
+class KohanaPSRLoggerTest extends TestCase
 {
-    use ProphecyTrait;
 
-    /**
-     * @var \Log
-     */
-    protected $log;
-
+    private Log $log;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->log = $this->prophesize(\Log::class);;
+        $this->log = new class extends Log {
+            public array $added = [];
+
+            public function add($level, $message, array $values = NULL, array $additional = NULL)
+            {
+                $this->added[] = get_defined_vars();
+            }
+        };
     }
 
     public function test_it_is_initializable()
@@ -37,83 +43,202 @@ class KohanaPSRLoggerTest extends \PHPUnit\Framework\TestCase
     public function test_it_logs_to_a_provided_kohana_log()
     {
         $this->newSubject()->info('Some message');
-        $this->log->add(Argument::cetera())->shouldHaveBeenCalled();
+        $this->assertCount(1, $this->log->added, "should have logged once");
     }
 
     public function test_it_logs_debug_messages()
     {
         $this->newSubject()->debug('some message');
-        $this->log->add(\Log::DEBUG, 'some message', Argument::cetera())->shouldHaveBeenCalled();
+        $this->assertSame(
+            [
+                [
+                    'level'      => Log::DEBUG,
+                    'message'    => 'some message',
+                    'values'     => [],
+                    'additional' => [],
+                ],
+            ],
+            $this->log->added
+        );
     }
 
     public function test_it_logs_info_messages()
     {
         $this->newSubject()->info('some message');
-        $this->log->add(\Log::INFO, 'some message', Argument::cetera())->shouldHaveBeenCalled();
+        $this->assertSame(
+            [
+                [
+                    'level'      => Log::INFO,
+                    'message'    => 'some message',
+                    'values'     => [],
+                    'additional' => [],
+                ],
+            ],
+            $this->log->added
+        );
     }
 
     public function test_it_logs_notice_messages()
     {
         $this->newSubject()->notice('some message');
-        $this->log->add(\Log::NOTICE, 'some message', Argument::cetera())->shouldHaveBeenCalled();
+        $this->assertSame(
+            [
+                [
+                    'level'      => Log::NOTICE,
+                    'message'    => 'some message',
+                    'values'     => [],
+                    'additional' => [],
+                ],
+            ],
+            $this->log->added
+        );
     }
 
     public function test_it_logs_warning_messages()
     {
         $this->newSubject()->warning('some message');
-        $this->log->add(\Log::WARNING, 'some message', Argument::cetera())->shouldHaveBeenCalled();
+        $this->assertSame(
+            [
+                [
+                    'level'      => Log::WARNING,
+                    'message'    => 'some message',
+                    'values'     => [],
+                    'additional' => [],
+                ],
+            ],
+            $this->log->added
+        );
     }
 
     public function test_it_logs_error_messages()
     {
         $this->newSubject()->error('some message');
-        $this->log->add(\Log::ERROR, 'some message', Argument::cetera())->shouldHaveBeenCalled();
+        $this->assertSame(
+            [
+                [
+                    'level'      => Log::ERROR,
+                    'message'    => 'some message',
+                    'values'     => [],
+                    'additional' => [],
+                ],
+            ],
+            $this->log->added
+        );
     }
 
     public function test_it_logs_critical_messages()
     {
         $this->newSubject()->critical('some message');
-        $this->log->add(\Log::CRITICAL, 'some message', Argument::cetera())->shouldHaveBeenCalled();
+        $this->assertSame(
+            [
+                [
+                    'level'      => Log::CRITICAL,
+                    'message'    => 'some message',
+                    'values'     => [],
+                    'additional' => [],
+                ],
+            ],
+            $this->log->added
+        );
     }
 
     public function test_it_logs_alert_messages()
     {
         $this->newSubject()->alert('some message');
-        $this->log->add(\Log::ALERT, 'some message', Argument::cetera())->shouldHaveBeenCalled();
+        $this->assertSame(
+            [
+                [
+                    'level'      => Log::ALERT,
+                    'message'    => 'some message',
+                    'values'     => [],
+                    'additional' => [],
+                ],
+            ],
+            $this->log->added
+        );
     }
 
     public function test_it_logs_emergency_messages()
     {
         $this->newSubject()->emergency('some message');
-        $this->log->add(\Log::EMERGENCY, 'some message', Argument::cetera())->shouldHaveBeenCalled();
+        $this->assertSame(
+            [
+                [
+                    'level'      => Log::EMERGENCY,
+                    'message'    => 'some message',
+                    'values'     => [],
+                    'additional' => [],
+                ],
+            ],
+            $this->log->added
+        );
     }
 
     public function test_it_passes_context_as_additional()
     {
-        $e = new \Exception('Foo');
-        $this->newSubject()->info('Something that we caught', ['exception' => $e]);
-        $this->log->add(\Log::INFO, Argument::type('string'), [], ['exception' => $e])->shouldHaveBeenCalled();
+        $e = new stdClass;
+        $this->newSubject()->info('Something that we caught', ['anything' => $e]);
+        $this->assertSame(
+            [
+                [
+                    'level'      => Log::INFO,
+                    'message'    => 'Something that we caught',
+                    'values'     => [],
+                    'additional' => ['anything' => $e],
+                ],
+            ],
+            $this->log->added
+        );
     }
 
     public function test_it_appends_exception_type_and_message_to_log_message()
     {
-        $e = new \Exception('Foo');
+        $e = new Exception('Foo');
         $this->newSubject()->info('We handled this', ['exception' => $e]);
-        $this->log->add(\Log::INFO, 'We handled this'.\PHP_EOL.\Kohana_Exception::text($e), Argument::cetera())
-            ->shouldHaveBeenCalled();
+        $this->assertSame(
+            [
+                [
+                    'level'      => Log::INFO,
+                    'message'    => 'We handled this'.PHP_EOL.Kohana_Exception::text($e),
+                    'values'     => [],
+                    'additional' => ['exception' => $e],
+                ],
+            ],
+            $this->log->added
+        );
     }
 
     public function test_it_copes_if_context_exception_is_not_exception_instance()
     {
         $this->newSubject()->info('Problem', ['exception' => 'Uh-oh - this is not an exception']);
-        $this->assertTrue(TRUE, 'Did not throw exception');
+        $this->assertSame(
+            [
+                [
+                    'level'      => Log::INFO,
+                    'message'    => 'Problem',
+                    'values'     => [],
+                    'additional' => ['exception' => 'Uh-oh - this is not an exception'],
+                ],
+            ],
+            $this->log->added
+        );
     }
 
     public function test_it_can_accept_exception_as_message()
     {
-        $e = new \Exception('Problem');
+        $e = new Exception('Problem');
         $this->newSubject()->alert($e);
-        $this->log->add(\Log::ALERT, \Kohana_Exception::text($e), [], ['exception' => $e])->shouldHaveBeenCalled();
+        $this->assertSame(
+            [
+                [
+                    'level'      => Log::ALERT,
+                    'message'    => Kohana_Exception::text($e),
+                    'values'     => [],
+                    'additional' => ['exception' => $e],
+                ],
+            ],
+            $this->log->added
+        );
     }
 
     public function test_it_throws_on_invalid_level()
@@ -122,12 +247,9 @@ class KohanaPSRLoggerTest extends \PHPUnit\Framework\TestCase
         $this->newSubject()->log('random', 'bad level');
     }
 
-    /**
-     * @return KohanaPSRLogger
-     */
-    protected function newSubject()
+    protected function newSubject(): KohanaPSRLogger
     {
-        return new KohanaPSRLogger($this->log->reveal());
+        return new KohanaPSRLogger($this->log);
     }
 
 }


### PR DESCRIPTION
There isn't yet a php8.2 supported version, composer install is only working because there are some ancient
versions of prophecy that do not have any php version constraint so composer is falling back to these.

We barely use it let's just rewrite the tests without it.