### PR TITLE
Log full exception for error reporting from DBALConnectionExceptionHa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ### Unreleased
 
+## v2.3.1 (2022-10-28)
+
+* Log the full exception for tracing / error reporting from the DBALConnectionExceptionHandler.
+
 ## v2.3.0 (2022-10-16)
 
 * Support PHP8.1 and PHP8.2

--- a/src/ExceptionHandling/DBALConnectionExceptionHandler.php
+++ b/src/ExceptionHandling/DBALConnectionExceptionHandler.php
@@ -16,8 +16,13 @@ class DBALConnectionExceptionHandler extends AbstractExceptionHandler
      */
     public function handle(\Throwable $e): ?\Response
     {
+        // Note that DBAL ConnectionException is thrown for a variety of error conditions including some that are
+        // more properly runtime errors e.g. incorrect use of transactions / rollback when no transaction active etc.
+        // So although we show the maintenance page for everything, we log these as a full exception for error reporting
+        // and review.
         $this->log->warning(
-            'DB connection error: '.\Kohana_Exception::text($e)
+            'DB connection error: '.\Kohana_Exception::text($e),
+            ['exception' => $e]
         );
 
         return $this->respondGenericErrorPage(static::PAGE_GENERIC_MAINTENANCE, 503);

--- a/test/unit/ExceptionHandling/DBALConnectionExceptionHandlerTest.php
+++ b/test/unit/ExceptionHandling/DBALConnectionExceptionHandlerTest.php
@@ -15,7 +15,7 @@ class DBALConnectionExceptionHandlerTest extends AbstractExceptionHandlerTest
         $this->assertInstanceOf(DBALConnectionExceptionHandler::class, $this->newSubject());
     }
 
-    public function test_it_logs_warning_without_full_exception_trace()
+    public function test_it_logs_warning_and_exception()
     {
         $e = new ConnectionException('SQL whatever from doctrine');
         $this->newSubject()->handle($e);
@@ -24,7 +24,9 @@ class DBALConnectionExceptionHandlerTest extends AbstractExceptionHandlerTest
                 [
                     'level'   => LogLevel::WARNING,
                     'message' => 'DB connection error: '.\Kohana_Exception::text($e),
-                    'context' => [],
+                    'context' => [
+                        'exception' => $e
+                    ],
                 ],
             ],
             $this->log->records


### PR DESCRIPTION
…ndler

DBAL throws ConnectionException in a variety of situations, some of which are more likely to be runtime application logic than transient network / server issues.

For now, keep serving a maintenance page for all of them, but include the exception in the log context so that it can trigger error reports / monitoring while we review whether/how to make the handler more specific in future.