### PR TITLE
Always attach Doctrine annotation reader to symfony validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 ### Unreleased
 
+## v3.1.0 (2024-02-09)
+
+* Reinstate default behaviour of symfony validator to create doctrine annotation reader which was subtly removed in validator v6 
+
 ## v3.0.0 (2024-02-08)
 
 * Drop support for PHP 8.0 & 8.1

--- a/src/DependencyFactory/SymfonyValidationFactory.php
+++ b/src/DependencyFactory/SymfonyValidationFactory.php
@@ -45,6 +45,7 @@ class SymfonyValidationFactory extends OptionalDependencyFactory
         // as a global autoloader.
         AnnotationRegistry::registerLoader(function ($class) { return \class_exists($class); });
         $builder = Validation::createValidatorBuilder();
+        $builder->addDefaultDoctrineAnnotationReader();
         $builder->enableAnnotationMapping();
 
         // @todo: need to enable metadata cache before using the validator from a web context


### PR DESCRIPTION
This behaviour was default until validator v6